### PR TITLE
Moved dogstreams_config check so we can use dogstreams.d exclusively.

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -39,11 +39,8 @@ class EventDefaults(object):
 class Dogstreams(object):
     @classmethod
     def init(cls, logger, config):
-        dogstreams_config = config.get('dogstreams', None)
-        if dogstreams_config:
-            dogstreams = cls._instantiate_dogstreams(logger, config, dogstreams_config)
-        else:
-            dogstreams = []
+        dogstreams = cls._instantiate_dogstreams(logger, config,
+                                                config.get('dogstreams', None))
 
         logger.info("Dogstream parsers: %s" % repr(dogstreams))
 
@@ -65,27 +62,28 @@ class Dogstreams(object):
         """
         # Load Dogstream objects from dogstreams.d.
         dogstreams = cls._load_dogstreams_from_dir(logger, config)
-        # Create a Dogstream object for each <dogstream value>
-        for config_item in dogstreams_config.split(','):
-            try:
-                config_item = config_item.strip()
-                parts = windows_friendly_colon_split(config_item)
-                if len(parts) == 1:
-                    # If the dogstream includes a wildcard, we'll add every
-                    # matching path.
-                    for path in cls._get_dogstream_log_paths(parts[0]):
-                        dogstreams.append(Dogstream.init(logger, log_path=path))
-                elif len(parts) == 2:
-                    logger.warn("Invalid dogstream: %s" % ':'.join(parts))
-                elif len(parts) >= 3:
-                    dogstreams.append(Dogstream.init(
-                        logger,
-                        log_path=parts[0],
-                        parser_spec=':'.join(parts[1:3]),
-                        parser_args=parts[3:],
-                        config=config))
-            except Exception:
-                logger.exception("Cannot build dogstream")
+        if dogstreams_config:
+            # Create a Dogstream object for each <dogstream value>
+            for config_item in dogstreams_config.split(','):
+                try:
+                    config_item = config_item.strip()
+                    parts = windows_friendly_colon_split(config_item)
+                    if len(parts) == 1:
+                        # If the dogstream includes a wildcard, we'll add every
+                        # matching path.
+                        for path in cls._get_dogstream_log_paths(parts[0]):
+                            dogstreams.append(Dogstream.init(logger, log_path=path))
+                    elif len(parts) == 2:
+                        logger.warn("Invalid dogstream: %s" % ':'.join(parts))
+                    elif len(parts) >= 3:
+                        dogstreams.append(Dogstream.init(
+                            logger,
+                            log_path=parts[0],
+                            parser_spec=':'.join(parts[1:3]),
+                            parser_args=parts[3:],
+                            config=config))
+                except Exception:
+                    logger.exception("Cannot build dogstream")
         return dogstreams
 
     @classmethod


### PR DESCRIPTION
I wanted to be able to use only the new dogstreams.d functionality, so I moved the check for the 'dogstreams' config option to after the directory loading logic.